### PR TITLE
Send tripwire violation counts to prometheus via node exporter.

### DIFF
--- a/jobs/tripwire/spec
+++ b/jobs/tripwire/spec
@@ -11,6 +11,7 @@ packages:
 templates:
   bin/cron_ctl: bin/cron_ctl
   bin/run-report.sh.erb: bin/run-report.sh
+  bin/aggregate-report.py: bin/aggregate-report.py
   bin/sleeper: bin/sleeper
   config/tripwire.erb: config/tripwire
   config/twcfg.txt.erb: config/twcfg.txt
@@ -23,7 +24,5 @@ templates:
 properties:
   tripwire.localpass:
     description: Local passphrase
-    default: "soverysecret"
   tripwire.sitepass:
     description: Site passphrase
-    default: "soverysecret"

--- a/jobs/tripwire/templates/bin/aggregate-report.py
+++ b/jobs/tripwire/templates/bin/aggregate-report.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import re
+import sys
+import shutil
+import tempfile
+import collections
+
+alert = re.compile(r'^".+"$')
+label = re.compile(r'[^a-z_]', re.IGNORECASE)
+
+def summarize(path):
+    with open(path) as fp:
+        lines = fp.readlines()
+    counts = {}
+    section = None
+    for line in lines:
+        if line.startswith('Rule Name:'):
+            section = line.split('Rule Name:')[-1].strip()
+            counts[section] = collections.defaultdict(int)
+            action = None
+        elif line.strip() == 'Added:':
+            action = 'add'
+        elif line.strip() == 'Modified:':
+            action = 'modify'
+        elif line.strip() == 'Removed:':
+            action = 'remove'
+        elif section is not None and action is not None and alert.match(line):
+            counts[section][action] += 1
+    return counts
+
+
+def format_summary(summary, output):
+    with tempfile.NamedTemporaryFile(delete=False) as fp:
+        for section, counts in summary.items():
+            for action, value in counts.items():
+                fp.write('tripwire_violation_count {{section="{section}" action="{action}"}} {value}\n'.format(
+                    section=label.sub('_', section.split('(')[0].lower()),
+                    action=action,
+                    value=value,
+                ))
+    shutil.move(fp.name, output)
+
+
+if __name__ == "__main__":
+    report = sys.argv[1]
+    output = sys.argv[2]
+
+    summary = summarize(report)
+    format_summary(summary, output)

--- a/jobs/tripwire/templates/bin/run-report.sh.erb
+++ b/jobs/tripwire/templates/bin/run-report.sh.erb
@@ -17,4 +17,9 @@ if [[ ! -f $LOCAL_KEY_PATH || ! -f $SITE_KEY_PATH ]]; then
   $PACKAGE_DIR/sbin/tripwire -m i ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %>
 fi
 
-$PACKAGE_DIR/sbin/tripwire -m c $TW_LOCATIONS -P <%= p('tripwire.localpass') %> | logger -t tripwire.report
+$PACKAGE_DIR/sbin/tripwire -m c $TW_LOCATIONS -P <%= p('tripwire.localpass') %> > report.txt
+logger -t tripwire.report -f report.txt
+
+/var/vcap/jobs/tripwire/bin/aggregate-report.py report.txt /var/vcap/jobs/node_exporter/config/tripwire.prom
+
+rm report.txt

--- a/jobs/tripwire/templates/config/twpol.txt.erb
+++ b/jobs/tripwire/templates/config/twpol.txt.erb
@@ -188,8 +188,8 @@ Temporary     = +pugt ;
   /lost+found                   -> $(Dynamic) ;
   /var/lost+found               -> $(Dynamic) ;
   /home/lost+found              -> $(Dynamic) ;
-  !/dev/pts ;			 # Ignore this file
-  !/dev/shm ;			 # Ignore this file
+  !/dev/pts ;      # Ignore this file
+  !/dev/shm ;      # Ignore this file
 }
 
   ################################################


### PR DESCRIPTION
* Ignore directories that BOSH writes for logs/ssh/etc
* Allow custom overrides for nessus and other jobs that write to system dirs