### PR TITLE
add python to tripwire so it actually works

### DIFF
--- a/.final_builds/packages/python3/index.yml
+++ b/.final_builds/packages/python3/index.yml
@@ -1,0 +1,6 @@
+builds:
+  09c10010e1696f0f15dcc7ca0411d06e5fc8ace7:
+    version: 09c10010e1696f0f15dcc7ca0411d06e5fc8ace7
+    blobstore_id: 02c91b3d-0e9a-42d1-42dc-604874c0c09a
+    sha1: 460333285dddb0d0c099806d8d475a74f8812c22
+format-version: "2"

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,5 +1,8 @@
----
+Python-3.7.5.tgz:
+  size: 23126230
+  object_id: 44d9137c-c5e6-4705-5849-d2c6d62d416d
+  sha: sha256:8ecc681ea0600bbfb366f2b173f727b205bb825d93d2f0b286bc4e58d37693da
 tripwire-open-source-2.4.3.1.tar.gz:
+  size: 932665
   object_id: 3f5dd4e6-d3ce-41fb-8533-be8b42241aa0
   sha: 8f04e9154aa56096cacaa4ce77bfba22d44a9a9d
-  size: 932665

--- a/jobs/tripwire/templates/bin/aggregate-report.py
+++ b/jobs/tripwire/templates/bin/aggregate-report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/var/vcap/packages/python3
 # -*- coding: utf-8 -*-
 
 import re

--- a/packages/python3/spec.lock
+++ b/packages/python3/spec.lock
@@ -1,0 +1,2 @@
+name: python3
+fingerprint: 09c10010e1696f0f15dcc7ca0411d06e5fc8ace7


### PR DESCRIPTION
the run-report script currently fails because there is no python for it to use. This should fix that.

a very, very big TODO here is figuring out when this script is failing, but I think that takes place on the prometheus side.