### PR TITLE
Python as a dependency

### DIFF
--- a/jobs/tripwire/spec
+++ b/jobs/tripwire/spec
@@ -7,6 +7,7 @@ description: |
 
 packages:
 - tripwire
+- python3
 
 templates:
   bin/cron_ctl: bin/cron_ctl

--- a/packages/tripwire/spec
+++ b/packages/tripwire/spec
@@ -1,6 +1,7 @@
 ---
 name: tripwire
 dependencies:
+- python3
 files:
 - tripwire-open-source-2.4.3.1.tar.gz
 - patches/tty-fix.patch


### PR DESCRIPTION
adding python as a package alone is not enough - tripwire needs to declare it as a dependency