### PR TITLE
Fix run script

### DIFF
--- a/jobs/tripwire/templates/bin/aggregate-report.py
+++ b/jobs/tripwire/templates/bin/aggregate-report.py
@@ -32,7 +32,7 @@ def summarize(path):
 
 
 def format_summary(summary, output):
-    with tempfile.NamedTemporaryFile(delete=False) as fp:
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as fp:
         for section, counts in summary.items():
             for action, value in counts.items():
                 fp.write('tripwire_violation_count {{section="{section}",action="{action}"}} {value}\n'.format(

--- a/jobs/tripwire/templates/bin/run-report.sh.erb
+++ b/jobs/tripwire/templates/bin/run-report.sh.erb
@@ -19,7 +19,11 @@ if [[ ! -f $LOCAL_KEY_PATH || ! -f $SITE_KEY_PATH ]]; then
   $PACKAGE_DIR/sbin/tripwire -m i ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %>
 fi
 
+# tripwire exits nonzero when it finds a modification, so we don't want to exit here
+set +e
 $PACKAGE_DIR/sbin/tripwire -m c $TW_LOCATIONS -P <%= p('tripwire.localpass') %> > report.txt
+set -e
+
 logger -t tripwire.report -f report.txt
 
 /var/vcap/jobs/tripwire/bin/aggregate-report.py report.txt /var/vcap/jobs/node_exporter/config/tripwire.prom


### PR DESCRIPTION
This fixes a problem I introduced by adding `set -e`, because tripwire exits nonzero when it finds something. 
It also fixes a problem with the python script that was causing it to fail to write to the tempfile. 