### PR TITLE
generate database after each deploy to reduce false positives

### DIFF
--- a/jobs/tripwire/spec
+++ b/jobs/tripwire/spec
@@ -14,6 +14,7 @@ templates:
   bin/run-report.sh.erb: bin/run-report.sh
   bin/aggregate-report.py: bin/aggregate-report.py
   bin/sleeper: bin/sleeper
+  bin/post-deploy: bin/post-deploy
   config/tripwire.erb: config/tripwire
   config/twcfg.txt.erb: config/twcfg.txt
   config/twpol.txt.erb: config/twpol.txt

--- a/jobs/tripwire/templates/bin/post-deploy
+++ b/jobs/tripwire/templates/bin/post-deploy
@@ -1,0 +1,17 @@
+
+JOB_NAME=tripwire
+JOB_DIR=/var/vcap/jobs/$JOB_NAME
+PACKAGE_DIR=/var/vcap/packages/tripwire
+KEY_DIR=${JOB_DIR}/keys
+LOCAL_KEY_PATH=${KEY_DIR}/local.key
+SITE_KEY_PATH=${KEY_DIR}/site.key
+TW_LOCATIONS="-L ${LOCAL_KEY_PATH} -S ${SITE_KEY_PATH}"
+
+if [[ ! -f $LOCAL_KEY_PATH || ! -f $SITE_KEY_PATH ]]; then
+  mkdir -p $KEY_DIR
+  $PACKAGE_DIR/sbin/twadmin -m G ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %> -Q <%= p('tripwire.sitepass') %>
+fi
+
+$PACKAGE_DIR/sbin/twadmin --create-cfgfile -S ${SITE_KEY_PATH} -Q <%= p('tripwire.sitepass') %> $JOB_DIR/config/twcfg.txt
+$PACKAGE_DIR/sbin/twadmin --create-polfile -S ${SITE_KEY_PATH} -Q <%= p('tripwire.sitepass') %> $JOB_DIR/config/twpol.txt
+$PACKAGE_DIR/sbin/tripwire -m i ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %>

--- a/jobs/tripwire/templates/bin/run-report.sh.erb
+++ b/jobs/tripwire/templates/bin/run-report.sh.erb
@@ -3,21 +3,12 @@
 set -ex
 
 JOB_NAME=tripwire
-JOB_DIR=/var/vcap/jobs/$JOB_NAME
+JOB_DIR=/var/vcap/jobs/${JOB_NAME}
 PACKAGE_DIR=/var/vcap/packages/tripwire
-KEY_DIR=$JOB_DIR/keys
+KEY_DIR=${JOB_DIR}/keys
 LOCAL_KEY_PATH=${KEY_DIR}/local.key
 SITE_KEY_PATH=${KEY_DIR}/site.key
 TW_LOCATIONS="-L ${LOCAL_KEY_PATH} -S ${SITE_KEY_PATH}"
-
-if [[ ! -f $LOCAL_KEY_PATH || ! -f $SITE_KEY_PATH ]]; then
-  mkdir -p $KEY_DIR
-  $PACKAGE_DIR/sbin/twadmin -m G ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %> -Q <%= p('tripwire.sitepass') %>
-
-  $PACKAGE_DIR/sbin/twadmin --create-cfgfile -S ${SITE_KEY_PATH} -Q <%= p('tripwire.sitepass') %> $JOB_DIR/config/twcfg.txt
-  $PACKAGE_DIR/sbin/twadmin --create-polfile -S ${SITE_KEY_PATH} -Q <%= p('tripwire.sitepass') %> $JOB_DIR/config/twpol.txt
-  $PACKAGE_DIR/sbin/tripwire -m i ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %>
-fi
 
 # tripwire exits nonzero when it finds a modification, so we don't want to exit here
 set +e

--- a/jobs/tripwire/templates/config/twpol.txt.erb
+++ b/jobs/tripwire/templates/config/twpol.txt.erb
@@ -321,6 +321,7 @@ Temporary     = +pugt ;
   /etc/cron.weekly                -> $(Growing);
   /etc/cron.monthly               -> $(Growing);
   /var/spool/mail                 -> $(Growing);
+  /var/vcap/sys/log               -> $(Growing) -i;
 }
 
   ################################################
@@ -352,4 +353,22 @@ Temporary     = +pugt ;
 )
 {
    !/proc ;                           # Ignore most of this directory
+}
+
+  ################################################
+ #                                              ##
+################################################ #
+#                                              # #
+#   Nessus Files                               # #
+#                                              ##
+################################################
+
+(
+  rulename = "Nessus Agent",
+)
+{
+  /opt/nessus_agent/var/nessus/backups/      -> $(Dynamic);
+  /opt/nessus_agent/var/nessus/global.db-wal -> $(Dynamic);
+  /opt/nessus_agent/var/nessus/global.db-wal -> $(Dynamic);
+  !/opt/nessus_agent/var/nessus/nessus.pid;
 }


### PR DESCRIPTION
# Changes in this PR
- previously, we generated the Tripwire database whenever we did not have keys in the key dir. Now, we generate it whenever a deployment finishes. This should reduce false positives.
- previously, we generated config and policy files only when there were no keys in the key dir. Now, we generate them after deploys. This should fix a bug where the config and policy files would never reload.
- added some configs about nessus.

# Security Considerations
This should improve our security posture by fixing bugs with tripwire and making tripwire alerts more actionable.