### PR TITLE
unduplicate nessus policy lines

### DIFF
--- a/jobs/tripwire/templates/config/twpol.txt.erb
+++ b/jobs/tripwire/templates/config/twpol.txt.erb
@@ -369,6 +369,6 @@ Temporary     = +pugt ;
 {
   /opt/nessus_agent/var/nessus/backups/      -> $(Dynamic);
   /opt/nessus_agent/var/nessus/global.db-wal -> $(Dynamic);
-  /opt/nessus_agent/var/nessus/global.db-wal -> $(Dynamic);
+  /opt/nessus_agent/var/nessus/global.db-shm -> $(Dynamic);
   !/opt/nessus_agent/var/nessus/nessus.pid;
 }


### PR DESCRIPTION
I accidentally included the same line twice in the nessus policy, which it hates I guess.

# Security Considerations
This will improve our security posture by allowing tripwire to deploy