### PR TITLE
add a shebang so tripwire post-deploy works

### DIFF
--- a/jobs/tripwire/templates/bin/post-deploy
+++ b/jobs/tripwire/templates/bin/post-deploy
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 JOB_NAME=tripwire
 JOB_DIR=/var/vcap/jobs/$JOB_NAME


### PR DESCRIPTION
This post-start script is failing because there's no shebang, and no shell when monit runs it. 

# Security Considerations
None - this bugfix will not change our security posture.