### PR TITLE
add vcap group to report-ran

### DIFF
--- a/jobs/tripwire/monit
+++ b/jobs/tripwire/monit
@@ -7,3 +7,4 @@ check process tripwire
 check file report-ran with path /var/vcap/data/report-ran
   if timestamp > 2 hours then alert
   depends on tripwire
+  group vcap


### PR DESCRIPTION
This sets the group to `vcap` on the tripwire report monitor. I think this is what's keeping bosh from seeing the failure.

# security considerations
If this works, it should improve our security posture by better assurances that tripwire is running.