### PR TITLE
Fix file tests

### DIFF
--- a/jobs/tripwire/monit
+++ b/jobs/tripwire/monit
@@ -4,7 +4,7 @@ check process tripwire
   stop program "/var/vcap/jobs/tripwire/bin/monit_debugger cron_ctl '/var/vcap/jobs/tripwire/bin/cron_ctl stop'"
   group vcap
 
-check file report-ran with path /var/vcap/data/report-ran
+check file tripwire-report-ran with path /var/vcap/data/tripwire/report-ran
   if timestamp > 2 hours then alert
   depends on tripwire
   group vcap

--- a/jobs/tripwire/templates/bin/pre-start
+++ b/jobs/tripwire/templates/bin/pre-start
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# this prevents the job from failing on startup
+touch /var/vcap/data/tripwire/report-ran


### PR DESCRIPTION
This change:
- gives the report-ran check a better name `tripwire-report-ran`
- corrects the report-ran file path in the monit tests
- adds a prestart script so the report-ran file will exist on startup, allowing monit to start

# security considerations
If this works, it will make it easier to confirm tripwire is running correctly, improving our security posture