### PR TITLE
include the pre-start script in the job

### DIFF
--- a/jobs/tripwire/spec
+++ b/jobs/tripwire/spec
@@ -15,6 +15,7 @@ templates:
   bin/aggregate-report.py: bin/aggregate-report.py
   bin/sleeper: bin/sleeper
   bin/post-deploy: bin/post-deploy
+  bin/pre-start: bin/pre-start
   config/tripwire.erb: config/tripwire
   config/twcfg.txt.erb: config/twcfg.txt
   config/twpol.txt.erb: config/twpol.txt


### PR DESCRIPTION
the prestart script isn't running because we didn't include it in the package. 

# Security Considerations
none.