### PR TITLE
update policy in database after deployment

### DIFF
--- a/jobs/tripwire/templates/bin/post-deploy
+++ b/jobs/tripwire/templates/bin/post-deploy
@@ -16,4 +16,7 @@ fi
 
 $PACKAGE_DIR/sbin/twadmin --create-cfgfile -S ${SITE_KEY_PATH} -Q <%= p('tripwire.sitepass') %> $JOB_DIR/config/twcfg.txt >> ${LOG_FILE} 2>&1
 $PACKAGE_DIR/sbin/twadmin --create-polfile -S ${SITE_KEY_PATH} -Q <%= p('tripwire.sitepass') %> $JOB_DIR/config/twpol.txt >> ${LOG_FILE} 2>&1
+# update the database
 $PACKAGE_DIR/sbin/tripwire -m i ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %> >> ${LOG_FILE} 2>&1
+# update the policy
+$PACKAGE_DIR/sbin/tripwire -m p ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %> -Q <%= p('tripwire.sitepass') ${JOB_DIR}/config/twpol.txt>> ${LOG_FILE} 2>&1


### PR DESCRIPTION
This lets us actually update the policy, rather than just generating a new policy file.

# Security considerations
This improves our security by allowing us to update our tripwire policy when necessary