### PR TITLE
base success on command output instead of rc

### DIFF
--- a/jobs/tripwire/templates/bin/post-deploy
+++ b/jobs/tripwire/templates/bin/post-deploy
@@ -19,4 +19,8 @@ $PACKAGE_DIR/sbin/twadmin --create-polfile -S ${SITE_KEY_PATH} -Q <%= p('tripwir
 # update the database
 $PACKAGE_DIR/sbin/tripwire -m i ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %> >> ${LOG_FILE} 2>&1
 # update the policy
-$PACKAGE_DIR/sbin/tripwire -m p ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %> -Q <%= p('tripwire.sitepass') %> ${JOB_DIR}/config/twpol.txt >> ${LOG_FILE} 2>&1
+update_result=$($PACKAGE_DIR/sbin/tripwire -m p ${TW_LOCATIONS} -P <%= p('tripwire.localpass') %> -Q <%= p('tripwire.sitepass') %> ${JOB_DIR}/config/twpol.txt)
+
+# tripwire return codes are mysterious. This checks the last line of output to try to see if it's good. 
+last_line=$(echo $update_result | tail -n 1)
+[[ ${last_line} =~ (Wrote database file: | policy and database filese were not altered) ]]


### PR DESCRIPTION
I think tripwire is returning non-zero in some cases of updates. This will hopefully fix it.

# Security Considerations
This should fix tripwire's policy updating, improving our security